### PR TITLE
Fix bug where charts fail to render where label contains apostrophe.

### DIFF
--- a/lib/node-svgchart/svg.js
+++ b/lib/node-svgchart/svg.js
@@ -54,10 +54,10 @@ var getTextMetrics = function(text, font, fontSize, styles) {
 					+ font
 				   + "' -pointsize "
 				    + fontSize
-				   + " -debug annotate -annotate 0 '"
-				    + text
-				   + "' null: 2>&1 | grep Metrics: | fmt -w80";
-	
+				   + " -debug annotate -annotate 0 \""
+				    + text.replace(/"/g, '\\\"')
+				   + "\" null: 2>&1 | grep Metrics: | fmt -w80";
+
 	var metricsRaw = execSync(command)
 	, metrics = {}
 	, m = null;

--- a/lib/svg/elements.js
+++ b/lib/svg/elements.js
@@ -544,9 +544,9 @@ function getTextMetrics(text, opt) {
 					+ font
 				   + "' -pointsize "
 				    + fontSize
-				   + " -debug annotate -annotate 0 '"
-				    + text
-				   + "' null: 2>&1 | grep Metrics: | fmt -w80";
+				   + " -debug annotate -annotate 0 \""
+				    + text.replace(/"/g, '\\\"')
+				   + "\" null: 2>&1 | grep Metrics: | fmt -w80";
 	
 	var metricsRaw = execSync(command)
 	, metrics = {}


### PR DESCRIPTION
Changed 'convert' command to wrap text in double quotes, so we can escape characters.
